### PR TITLE
Update frontendMastersLink

### DIFF
--- a/course.json
+++ b/course.json
@@ -5,7 +5,7 @@
   },
   "title": "Complete Intro to MCP",
   "subtitle": "Getting started with AI agents and model context protocol tools",
-  "frontendMastersLink": "https://frontendmasters.com/courses/mcp/",
+  "frontendMastersLink": "https://frontendmasters.com/workshops/complete-intro-mcp/",
   "social": {
     "linkedin": "btholt",
     "github": "btholt",


### PR DESCRIPTION
The https://frontendmasters.com/courses/mcp/ leads to 404. I guess the course was moved.