### PR TITLE
Fixed code block in A-my-first-mcp-server.md

### DIFF
--- a/lessons/04-lets-build-mcp/A-my-first-mcp-server.md
+++ b/lessons/04-lets-build-mcp/A-my-first-mcp-server.md
@@ -55,6 +55,7 @@ server.registerTool(
     return {
         content: [{ type: "text", text: String(a + b) }],
     }
+  }
 );
 
 // Start receiving messages on stdin and sending messages on stdout


### PR DESCRIPTION
The code block was missing a close curly brace for the async function associated with the add tool. Copying code directly created resulted in error when trying to run it. With this change copy and pasting code works as expected